### PR TITLE
Migrate to latest (Dev) Local and Client Cloud versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
-# dev-local-tu
+# datomic-local-tu
 
-Test utility for Datomic dev-local. 
+Test utility for Datomic Local.
 
 ```clojure
 dev-local-tu {:mvn/version "0.3.0"}
 ```
 
-## Rationale 
+## Rationale
 
-Datomic dev-local provides a way to create clean environments useful for testing.
-It does not provide a methodology for how to use it. 
-This library provides an opinionated way to use dev-local in your tests.
+Datomic Local provides a way to create clean environments useful for testing.
+It does not provide a methodology for how to use it.
+This library provides an opinionated way to use `:datomic-local` in your tests.
 
 ## Usage
 
-The primary function exposed by the api is `test-env`. 
+The primary function exposed by the api is `test-env`.
 This function returns a test environment.
-A test environment will contain a Datomic client, created by dev local, that can be cleaned up by simply calling `.close`.
+A test environment will contain a Datomic client, created by Datomic Local,
+that can be cleaned up by simply calling `.close`.
 A test environment is typically used within a `with-open`.
 
 ```clojure
-(require '[dev-local-tu.core :as dev-local-tu]
+(require '[datomic-local-tu.core :as datomic-local-tu]
          '[datomic.client.api :as d])
 
-(with-open [db-env (dev-local-tu/test-env)]
+(with-open [db-env (datomic-local-tu/test-env)]
   (let [_ (d/create-database (:client db-env) {:db-name "test"})
         conn (d/connect (:client db-env) {:db-name "test"})
         _ (d/transact conn {:tx-data [{:db/ident       ::name
@@ -37,9 +38,10 @@ A test environment is typically used within a `with-open`.
 => #:example1{:name "hi"}
 ```
 
-If you would prefer to manage the lifecycle, use `new-env` to generate a new, random system and `cleanup-env!` to remove the associated resources.
+If you would prefer to manage the lifecycle, use `new-env` to generate a new,
+random system and `cleanup-env!` to remove the associated resources.
 
-Alternatively, you can use test-env with fixtures. 
+Alternatively, you can use test-env with fixtures.
 See `examples/example_fixture.clj` for the complete example.
 
 ```clojure
@@ -47,9 +49,13 @@ See `examples/example_fixture.clj` for the complete example.
 
 (defn client-fixture
   [f]
-  (with-open [db-env (dev-local-tu/test-env)]
+  (with-open [db-env (datomic-local-tu/test-env)]
     (binding [*client* (:client db-env)]
       (f))))
 
 (use-fixtures :each client-fixture)
 ```
+
+## Author
+
+Kenny Williams @kennyjwilli

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Test utility for Datomic dev-local. 
 
 ```clojure
-dev-local-tu {:mvn/version "0.2.2"}
+dev-local-tu {:mvn/version "0.3.0"}
 ```
 
 ## Rationale 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Test utility for Datomic Local.
 
 ```clojure
-org.clojars.marksto/datomic-local-tu {:mvn/version "1.0.1"}
+org.clojars.marksto/datomic-local-tu {:mvn/version "1.0.2"}
 ```
 
 ## Rationale

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Test utility for Datomic Local.
 
 ```clojure
-dev-local-tu {:mvn/version "0.3.0"}
+org.clojars.marksto/datomic-local-tu {:mvn/version "1.0.0"}
 ```
 
 ## Rationale

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Test utility for Datomic Local.
 
 ```clojure
-org.clojars.marksto/datomic-local-tu {:mvn/version "1.0.0"}
+org.clojars.marksto/datomic-local-tu {:mvn/version "1.0.1"}
 ```
 
 ## Rationale

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,9 @@
-{:deps    {}
- :aliases {:dev {:extra-paths ["examples"]
-                 :extra-deps  {com.datomic/client-cloud {:mvn/version "0.8.102"}
-                               com.datomic/dev-local    {:local/root "dev-local-0.9.225.jar"}}}
-           :jar {:extra-deps {seancorfield/depstar {:mvn/version "1.1.132"}}
-                 :main-opts  ["-m" "hf.depstar.jar" "lib.jar"]}}}
+{:deps      {}
+
+ :mvn/repos {"datomic-cloud" {:url "s3://datomic-releases-1fc2183a/maven/releases"}}
+
+ :aliases   {:dev {:extra-paths ["examples"]
+                   :extra-deps  {com.datomic/client-cloud {:mvn/version "1.0.123"}
+                                 com.datomic/local        {:mvn/version "1.0.267"}}}
+             :jar {:extra-deps {seancorfield/depstar {:mvn/version "1.1.132"}}
+                   :main-opts  ["-m" "hf.depstar.jar" "lib.jar"]}}}

--- a/examples/example1.clj
+++ b/examples/example1.clj
@@ -2,10 +2,10 @@
   (:require
     [clojure.test :refer :all]
     [datomic.client.api :as d]
-    [dev-local-tu.core :as dev-local-tu]))
+    [datomic-local-tu.core :as datomic-local-tu]))
 
 (deftest test1
-  (with-open [db-env (dev-local-tu/test-env)]
+  (with-open [db-env (datomic-local-tu/test-env)]
     (let [_ (d/create-database (:client db-env) {:db-name "test"})
           conn (d/connect (:client db-env) {:db-name "test"})
           _ (d/transact conn {:tx-data [{:db/ident       ::name

--- a/examples/example_fixture.clj
+++ b/examples/example_fixture.clj
@@ -2,13 +2,13 @@
   (:require
     [clojure.test :refer :all]
     [datomic.client.api :as d]
-    [dev-local-tu.core :as dev-local-tu]))
+    [datomic-local-tu.core :as datomic-local-tu]))
 
 (def ^:dynamic *client* nil)
 
 (defn client-fixture
   [f]
-  (with-open [db-env (dev-local-tu/test-env)]
+  (with-open [db-env (datomic-local-tu/test-env)]
     (binding [*client* (:client db-env)]
       (f))))
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,10 @@
   <build>
     <sourceDirectory>src</sourceDirectory>
   </build>
+  <scm>
+    <url>https://github.com/marksto/dev-local-tu/</url>
+    <tag>f38f96dec3a8a12c0109c65707651c019ab614f8</tag>
+  </scm>
   <repositories>
     <repository>
       <id>clojars</id>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.clojars.marksto</groupId>
   <artifactId>datomic-local-tu</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <name>datomic-local-tu</name>
   <dependencies>
     <dependency>
@@ -17,7 +17,7 @@
   </build>
   <scm>
     <url>https://github.com/marksto/datomic-local-tu/</url>
-    <tag>f38f96dec3a8a12c0109c65707651c019ab614f8</tag>
+    <tag>aa65bae785704447a497e1552dadc87ba8235ce8</tag>
   </scm>
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>dev-local-tu</groupId>
-  <artifactId>dev-local-tu</artifactId>
-  <version>0.3.0</version>
-  <name>dev-local-tu</name>
+  <groupId>org.clojars.marksto</groupId>
+  <artifactId>datomic-local-tu</artifactId>
+  <version>1.0.0</version>
+  <name>datomic-local-tu</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure</groupId>
@@ -20,5 +20,15 @@
       <id>clojars</id>
       <url>https://repo.clojars.org/</url>
     </repository>
+    <repository>
+      <id>datomic-cloud</id>
+      <url>s3://datomic-releases-1fc2183a/maven/releases</url>
+    </repository>
   </repositories>
+  <licenses>
+    <license>
+      <name>Eclipse Public License</name>
+      <url>http://www.eclipse.org/legal/epl-v10.html</url>
+    </license>
+  </licenses>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <sourceDirectory>src</sourceDirectory>
   </build>
   <scm>
-    <url>https://github.com/marksto/dev-local-tu/</url>
+    <url>https://github.com/marksto/datomic-local-tu/</url>
     <tag>f38f96dec3a8a12c0109c65707651c019ab614f8</tag>
   </scm>
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.10.1</version>
+      <version>1.11.1</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.11.1</version>
+      <version>1.12.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.clojars.marksto</groupId>
   <artifactId>datomic-local-tu</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <name>datomic-local-tu</name>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>dev-local-tu</groupId>
   <artifactId>dev-local-tu</artifactId>
-  <version>0.2.2</version>
+  <version>0.3.0</version>
   <name>dev-local-tu</name>
   <dependencies>
     <dependency>

--- a/src/datomic_local_tu/internal/impl.clj
+++ b/src/datomic_local_tu/internal/impl.clj
@@ -1,4 +1,4 @@
-(ns dev-local-tu.internal.impl
+(ns datomic-local-tu.internal.impl
   (:require [clojure.java.io :as io])
   (:import (java.nio.file Files SimpleFileVisitor FileVisitResult)
            (java.security SecureRandom)

--- a/src/dev_local_tu/core.clj
+++ b/src/dev_local_tu/core.clj
@@ -63,7 +63,7 @@
   "Releases all DBs."
   [client system]
   (doseq [db-name (d/list-databases client {})]
-    ;; https://docs.datomic.com/cloud/datomic-local.html#release-db
+    ;; See "https://docs.datomic.com/api/datomic-local.html#release-db"
     (datomic.local/release-db
       {:system system :db-name db-name})))
 
@@ -95,8 +95,8 @@
 
    When closed, the test environment will release the resources used by the client
    and delete the data directory."
-  ([] (test-env {}))
-  ([env-argm]
+  (^TestEnv [] (test-env {}))
+  (^TestEnv [env-argm]
    (let [env (-new-env-map env-argm)]
      (map->TestEnv env))))
 

--- a/src/dev_local_tu/core.clj
+++ b/src/dev_local_tu/core.clj
@@ -51,11 +51,9 @@
   ([system-name storage-dir]
    (let [f (dev-local-directory {:system-name system-name
                                  :storage-dir storage-dir})]
-     (if (.exists ^File f)
-       (do
-         (impl/delete-directory! f)
-         true)
-       true))))
+     (when (.exists ^File f)
+       (impl/delete-directory! f))
+     true)))
 
 (comment
   (-new-env-map {})

--- a/src/dev_local_tu/core.clj
+++ b/src/dev_local_tu/core.clj
@@ -2,7 +2,7 @@
   (:require
     [clojure.string :as str]
     [datomic.client.api :as d]
-    [datomic.dev-local]
+    [datomic.local]
     [clojure.java.io :as io]
     [dev-local-tu.internal.impl :as impl])
   (:import (java.io Closeable File)))
@@ -36,7 +36,7 @@
                           (cond-> {}
                             storage-dir
                             (assoc ::storage-dir storage-dir)))))
-        client-map {:server-type :dev-local
+        client-map {:server-type :datomic-local
                     :system      system
                     :storage-dir storage-dir}]
     {:client      (d/client client-map)
@@ -65,8 +65,8 @@
   "Releases all DBs."
   [client system]
   (doseq [db-name (d/list-databases client {})]
-    ;; https://docs.datomic.com/cloud/dev-local.html#release-db
-    (datomic.dev-local/release-db
+    ;; https://docs.datomic.com/cloud/datomic-local.html#release-db
+    (datomic.local/release-db
       {:system system :db-name db-name})))
 
 (defn cleanup-env!

--- a/src/dev_local_tu/core.clj
+++ b/src/dev_local_tu/core.clj
@@ -15,8 +15,8 @@
   (.getAbsolutePath (io/file (System/getProperty "user.home") ".datomic" "data")))
 
 (defn dev-local-directory
-  [{:keys [system-name db-name storage-dir]
-    :or   {storage-dir default-datomic-dev-local-storage-dir}}]
+  ^File [{:keys [system-name db-name storage-dir]
+          :or   {storage-dir default-datomic-dev-local-storage-dir}}]
   (let [file-args (cond-> [storage-dir]
                     system-name (conj system-name)
                     db-name (conj db-name))]


### PR DESCRIPTION
Hi Kenny,

Thank you for a cute testing lib! It's been a while since your last last commit to the repo though, and things have changed in a way that makes it impossible the further use of this testing lib with the (currently) latest version of Datomic Cloud.

The following things [have changed](https://docs.datomic.com/cloud/datomic-local.html?search=1.0.126#267):
- Dev Local name — from `dev-local` to just `local`
- `local` is released under Apache 2.0, thus available through Maven
- `:server-type` value — from `:dev-local` to `:datomic-local`

Here's a small patch that implements the necessary changes in `dev-local-tu`. I've also upgraded Clojure version to `1.11.1`, which is currently the [latest stable one](https://clojure.org/releases/downloads#_stable_release_1_11_1_apr_5_2022). I also tweaked an obviously verbose piece of code and fixed a compiler reflection warning (pardon for shipping this along).

Feel free to review and release an updated version of the artifact at your convenience.

Cheers,
Mark